### PR TITLE
Fix error handling.

### DIFF
--- a/src/leveldb/lib_leveldb.cr
+++ b/src/leveldb/lib_leveldb.cr
@@ -8,19 +8,19 @@ lib LibLevelDB
   end
 
   # DB
-  fun leveldb_open(options : Void*, name : UInt8*,  errptr : Void*) : Void*
-  fun leveldb_put(db : Void*, woptions : Void*, key : UInt8*, keylen : UInt64, val : UInt8*, vallen : UInt64, errptr : Void*) : Void
-  fun leveldb_get(db : Void*, roptions : Void*, key : UInt8*, keylen : UInt64, vallen : UInt64*, errptr : Void*) : UInt8*
-  fun leveldb_delete(db : Void*, woptions : Void*, key : UInt8*, keylen : UInt64, errptr : Void*) : Void
+  fun leveldb_open(options : Void*, name : UInt8*, errptr : UInt8**) : Void*
+  fun leveldb_put(db : Void*, woptions : Void*, key : UInt8*, keylen : UInt64, val : UInt8*, vallen : UInt64, errptr : UInt8**) : Void
+  fun leveldb_get(db : Void*, roptions : Void*, key : UInt8*, keylen : UInt64, vallen : UInt64*, errptr : UInt8**) : UInt8*
+  fun leveldb_delete(db : Void*, woptions : Void*, key : UInt8*, keylen : UInt64, errptr : UInt8**) : Void
   fun leveldb_close(db : Void*)
-  fun leveldb_destroy_db(options : Void*, name : UInt8*, errptr : Void*)
+  fun leveldb_destroy_db(options : Void*, name : UInt8*, errptr : UInt8**)
 
   # Options
-  fun leveldb_options_create() : Void*
+  fun leveldb_options_create : Void*
   fun leveldb_options_set_create_if_missing(options : Void*, val : Bool)
   fun leveldb_options_set_compression(options : Void*, val : Compression)
-  fun leveldb_writeoptions_create() : Void*
-  fun leveldb_readoptions_create() : Void*
+  fun leveldb_writeoptions_create : Void*
+  fun leveldb_readoptions_create : Void*
 
   # Snapshot
   fun leveldb_create_snapshot(db : Void*) : Void*
@@ -29,14 +29,14 @@ lib LibLevelDB
 
   # Iterator
   fun leveldb_create_iterator(db : Void*, roptions : Void*) : Void*
-  fun leveldb_iter_destroy(iterator : Void *);
+  fun leveldb_iter_destroy(iterator : Void*)
   fun leveldb_iter_next(iterator : Void*)
   fun leveldb_iter_key(iterator : Void*, klen : SizeT*) : UInt8*
   fun leveldb_iter_value(iterator : Void*, vlen : SizeT*) : UInt8*
-  fun leveldb_iter_get_error(iterator : Void*, errptr : Void*)
+  fun leveldb_iter_get_error(iterator : Void*, errptr : UInt8**)
   fun leveldb_iter_seek_to_first(iterator : Void*)
   fun leveldb_iter_seek_to_last(iterator : Void*)
-  fun leveldb_iter_seek(iterator : Void*, key : UInt8*, klen : SizeT);
+  fun leveldb_iter_seek(iterator : Void*, key : UInt8*, klen : SizeT)
   fun leveldb_iter_valid(iterator : Void*) : Bool
 
   # Misc


### PR DESCRIPTION
Running specs on master w/ 0.21.1 I got:

```
Invalid memory access (signal 11) at address 0x0
[4459433179] *CallStack::print_backtrace:Int32 +107
[4459379463] __crystal_sigfault_handler +55
[140736114596666] _sigtramp +26
[4460655070] _Z9SaveErrorPPcRKN7leveldb6StatusE +26
[4460654944] leveldb_open +96
[4459785091] *LevelDB::DB#initialize<String>:Bool +211
[4459784857] *LevelDB::DB::new<String>:LevelDB::DB +137
[4459389083] ~procProc(Nil)@spec/leveldb/db_spec.cr:5 +571
[4459392043] *it<String, String, Int32, Int32, &Proc(Nil)>:(Array(Spec::Result) | Nil) +379
[4459388147] ~procProc(Nil)@spec/leveldb/db_spec.cr:4 +115
[4459670866] *Spec::RootContext::describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +354
[4459393593] *describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +9
[4459388011] ~procProc(Nil)@spec/leveldb/db_spec.cr:3 +107
[4459670866] *Spec::RootContext::describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +354
[4459403059] *describe<LevelDB:Module, String, Int32, &Proc(Nil)>:Spec::Context+ +51
[4459314439] __crystal_main +3543
[4459379208] main +40
```

Based on advice from `jhass` in the chat and looking at 
[levedb c api](https://github.com/google/leveldb/blob/master/include/leveldb/c.h#L72-L75) 
converted to use 
[out param](https://crystal-lang.org/docs/syntax_and_semantics/c_bindings/out.html).  
Specs pass now.